### PR TITLE
Fix NaN total L1 fees

### DIFF
--- a/components/L1List.tsx
+++ b/components/L1List.tsx
@@ -10,7 +10,7 @@ const L1List: React.FC<ListProps> = ({ data }) => {
     .filter((protocol: any) => !!protocol.result)
     .sort((a: any, b: any) => b.result - a.result);
 
-  const total = data.reduce((total: number, row: any) => total + row.result, 0);
+  const total = data.reduce((total: number, row: any) => total + (row.result || 0), 0);
 
   return (
     <div className="list">

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -17,7 +17,7 @@ export const bundleItems = (data: any[], bundles: any) => {
 
         for (const bundleItem of bundleItems) {
           _data.splice(_data.indexOf(bundleItem), 1);
-          result += bundleItem.result;
+          result += bundleItem.result || 0;
         }
 
         _data.push({


### PR DESCRIPTION
I'm getting NaN value in the "Total" row in L1 Security Costs tab. The main reason is the NaN value inside the result of the data prop of L1List. I fixed this by simply adding 0 to the total if the result is invalid.

I think the reason for the NaN is an error in the API call that is supposed to get the DeversiFi fees. This causes the results of the children of StarkNet in the bundleItems function to not be added correctly. I fixed this similarly by just adding 0 if the current result is invalid.

![firefox_Z2cGFQYFIu](https://user-images.githubusercontent.com/5159852/154540081-e33a7ad3-4385-4109-bc4c-e041b9da31a2.png)
![firefox_6GUFhJZ5K0](https://user-images.githubusercontent.com/5159852/154540311-5c91a094-a7fd-4af4-8c92-7f57b4179a3e.png)

