### PR TITLE
Increase fraction digits on cost after Duncen upgrade

### DIFF
--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -21,13 +21,17 @@ const toggle = (isOpen: boolean) => !isOpen;
 
 const cardHeight = 600;
 
+const minimumFractionDigits = 4;
+const minimum = 1 / 10 ** minimumFractionDigits;
+
 const format = (num?: number) =>
   (num &&
-    (num < 0.01
-      ? '< $0.01'
+    (num < minimum
+      ? `< $${minimum}`
       : num?.toLocaleString('en-US', {
           style: 'currency',
           currency: 'USD',
+          minimumFractionDigits,
         }))) ||
   '-';
 

--- a/components/Row.tsx
+++ b/components/Row.tsx
@@ -23,7 +23,7 @@ const cardHeight = 600;
 
 const minimumFractionDigits = 4;
 const minimum = 1 / 10 ** minimumFractionDigits;
-
+// no-op
 const format = (num?: number) =>
   (num &&
     (num < minimum


### PR DESCRIPTION
With the move to Duncen many L2s now cost less than 1 cent. This PR adds more decimal places so we can get a better idea on cost.

Before:
<img width="607" alt="image" src="https://github.com/dmihal/l2-fees/assets/1979423/1ee95774-4508-4801-9725-82d8685e3aa0">


After:
<img width="607" alt="image" src="https://github.com/dmihal/l2-fees/assets/1979423/7e9270d9-3cdb-4650-aee8-37618ee07334">


